### PR TITLE
Add SPDX-License-Identifier to earthly-mode.el

### DIFF
--- a/earthly-mode.el
+++ b/earthly-mode.el
@@ -4,6 +4,7 @@
 ;; URL: https://github.com/earthly/earthly-mode
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26"))
+;; SPDX-License-Identifier: MPL-2.0
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
In order to publish to MELPA, the MELPA maintainer suggest to add `SPDX-License-Identifier` to the `earthly-mode.el`

Reference to comment https://github.com/melpa/melpa/pull/7701#issuecomment-907850127